### PR TITLE
Stop extraneous fetch of belongsTo when model is empty

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -112,6 +112,13 @@ export default Ember.Mixin.create({
     //called when a belongsTo property changes
     this._super(...arguments);
 
+    // If a relation is loaded but empty (e.g. linkage data was supplied but unused), then
+    // loading the resource will cause an external request. In this case, do nothing
+    // unless the record has been fully loaded.
+    if (this._internalModel._relationships.get(key).inverseRecord && this._internalModel._relationships.get(key).inverseRecord.isEmpty()) {
+      return;
+    }
+
     //if a belongsTo relationship attribute has changed, and the new record has an id,
     //store the record in a property so that the belongsToSticky can return if it required
     var value = this.get(key);


### PR DESCRIPTION
Hi,

I noticed a bug where if you have linkage data with no attributes passed through on a server request, e.g:

    {
       data: {
          ...
         relationships: {
           other-model: { 
             data: {
               type: 'my-other-model',
               id: 123
             }
           }
           ...
         }
     }

the sticky code will cause a server request for every single one of these properties, as it calls `get` on the empty object.

I've put a temporary fix in that works for me, by inspecting if it's empty before doing anything else. No idea if you want to keep this or find some other way of dealing with this problem, but I figured I'd send it through in case it's useful.

Best,
Hugh