### PR TITLE
Update to babel 6

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -56,7 +56,7 @@ export default Ember.Mixin.create({
     var _queryIdPropertyName = queryIdPropertyName(propertyName);
     var currentQueryId = queryId++;
 
-    const oldParams = this.get(_queryParamPropertyName, params)
+    const oldParams = this.get(_queryParamPropertyName, params);
 
     this.set(_queryParamPropertyName, params);
     this.set(_queryIdPropertyName, currentQueryId);
@@ -97,7 +97,7 @@ export default Ember.Mixin.create({
       //run.next, so that aborted promise gets rejected before starting another
       Ember.run.next(this, function () {
         var isLoaded = reference.value() !== null;
-        if (isLoaded || force) {
+        if (isLoaded || forceReload) {
           resolve(reference.reload());
         } else {
           //isLoaded is false when the last query resulted in an error, so if this load

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-has-many-query",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Ember data addon for querying async has-many relationships using query parameters",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
@@ -51,7 +51,7 @@
     "pagination"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This is [a subset of](https://github.com/mdehoog/ember-data-has-many-query/pull/32/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R24) #32; but is much simpler to merge — and, importantly, allows dependants of this package to shut up their `ember-cli-babel@5` warnings.

Note that the fix is @vshaddix's, not mine; but we pushed his fork to `npm`, so we could depend on that and move on with other things; if you're suffering from this, and don't want to wait on a fix, feel free to switch to our fork temporarily:

```
$ npm uninstall ember-data-has-many-query && \
   npm install @codeverse/ember-data-has-many-query@0.2.1
```

Note one that I'm new to Ember, and maybe screwed something up — feel free to yell at me here, I'm following this thread; and two, that we're unlikely to support this past `0.2.1`; so remember to restore your dependency back to the upstream if #32 gets merged and published. `(=`