### PR TITLE
fix: force reference to be reloaded when params have changed

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -88,7 +88,7 @@ export default Mixin.create({
    * @param propertyName Relationship property name
    * @returns {Ember.RSVP.Promise}
    */
-  reloadRelationship: function (propertyName) {
+  reloadRelationship: function (propertyName, forceReload) {
     //find out what kind of relationship this is
     const relationship = this.relationshipFor(propertyName);
     const isHasMany = relationship && relationship.kind === 'hasMany';
@@ -99,7 +99,7 @@ export default Mixin.create({
       //run.next, so that aborted promise gets rejected before starting another
       next(this, function () {
         const isLoaded = reference.value() !== null;
-        if (isLoaded) {
+        if (isLoaded || forceReload) {
           resolve(reference.reload());
         } else {
           //isLoaded is false when the last query resulted in an error, so if this load


### PR DESCRIPTION
When upgrading Ember to 3.28, our has-many relationships are not loaded anymore.

It seems that a little bug was introduced by this commit [4c6f15d3a4af824236801c1efc74f960f5eff0aa](https://github.com/mdehoog/ember-data-has-many-query/commit/4c6f15d3a4af824236801c1efc74f960f5eff0aa): we can see that in the `addon/mixins/model.js` file, the `reloadRelationship` is still called with 2 arguments, but the definition of this function has been modified by removing this 2nd argument (forceReload).

With this version of the code, our code is running smoothly.